### PR TITLE
이미지 수정 처리 배포

### DIFF
--- a/src/main/java/com/supercoding/hackathon01/entity/Home.java
+++ b/src/main/java/com/supercoding/hackathon01/entity/Home.java
@@ -71,7 +71,7 @@ public class Home {
     @Column(name = "is_deleted")
     private Boolean isDeleted;
 
-    @OneToMany(mappedBy = "home", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "home", cascade = CascadeType.ALL)
     private List<Picture> pictures = new ArrayList<>();
 
     @Size(max = 45)

--- a/src/main/java/com/supercoding/hackathon01/service/HomeService.java
+++ b/src/main/java/com/supercoding/hackathon01/service/HomeService.java
@@ -52,31 +52,17 @@ public class HomeService {
         List<Picture> pictures = new ArrayList<>();
 
         if (imageFiles != null) {
-
-            List<Picture> originPicture = pictureRepository.findByHome(home);
-            originPicture.forEach(picture -> {
-                if (Boolean.FALSE.equals(picture.getIsThumbnail())) {
-                    deletedFile(picture.getUrl());
-                    pictureRepository.deleteById(picture.getId());
-                }
-            });
-
             imageFiles.forEach(file -> pictures.add(Picture.of(uploadImageFile(file, home), home, false)));
             pictureRepository.saveAll(pictures);
         }
         if (thumbnailImage != null) {
-
-            List<Picture> originPicture = pictureRepository.findByHome(home);
-
-            originPicture.forEach(picture -> {
-                if (Boolean.TRUE.equals(picture.getIsThumbnail())) {
-                    deletedFile(picture.getUrl());
-                    pictureRepository.deleteById(picture.getId());
-                }
-            });
             Picture thumbnail = Picture.of(uploadImageFile(thumbnailImage, home), home, true);
             pictureRepository.save(thumbnail);
         }
+
+
+
+
     }
 
     @Transactional
@@ -104,12 +90,27 @@ public class HomeService {
 
         if (imageFiles != null) {
 
-
+            List<Picture> originPicture = pictureRepository.findByHome(originHome);
+            originPicture.forEach(picture -> {
+                if (Boolean.FALSE.equals(picture.getIsThumbnail())) {
+                    deletedFile(picture.getUrl());
+                    pictureRepository.deleteById(picture.getId());
+                }
+            });
 
             imageFiles.forEach(file -> pictures.add(Picture.of(uploadImageFile(file, newHome), newHome, false)));
             pictureRepository.saveAll(pictures);
         }
         if (thumbnailImage != null) {
+
+            List<Picture> originPicture = pictureRepository.findByHome(originHome);
+
+            originPicture.forEach(picture -> {
+                if (Boolean.TRUE.equals(picture.getIsThumbnail())) {
+                    deletedFile(picture.getUrl());
+                    pictureRepository.deleteById(picture.getId());
+                }
+            });
             Picture thumbnail = Picture.of(uploadImageFile(thumbnailImage, newHome), newHome, true);
             pictureRepository.save(thumbnail);
         }

--- a/src/main/java/com/supercoding/hackathon01/service/HomeService.java
+++ b/src/main/java/com/supercoding/hackathon01/service/HomeService.java
@@ -82,10 +82,6 @@ public class HomeService {
         address.setId(originAddress.getId());
         addressRepository.save(address);
 
-        List<Picture> removePictures = pictureRepository.findByHome(newHome);
-        removePictures.forEach(picture -> awsS3Service.removeFile(picture.getUrl()));
-        pictureRepository.deleteAll(removePictures);
-
         List<Picture> pictures = new ArrayList<>();
 
         if (imageFiles != null) {

--- a/src/main/java/com/supercoding/hackathon01/service/HomeService.java
+++ b/src/main/java/com/supercoding/hackathon01/service/HomeService.java
@@ -52,17 +52,31 @@ public class HomeService {
         List<Picture> pictures = new ArrayList<>();
 
         if (imageFiles != null) {
+
+            List<Picture> originPicture = pictureRepository.findByHome(home);
+            originPicture.forEach(picture -> {
+                if (Boolean.FALSE.equals(picture.getIsThumbnail())) {
+                    deletedFile(picture.getUrl());
+                    pictureRepository.deleteById(picture.getId());
+                }
+            });
+
             imageFiles.forEach(file -> pictures.add(Picture.of(uploadImageFile(file, home), home, false)));
             pictureRepository.saveAll(pictures);
         }
         if (thumbnailImage != null) {
+
+            List<Picture> originPicture = pictureRepository.findByHome(home);
+
+            originPicture.forEach(picture -> {
+                if (Boolean.TRUE.equals(picture.getIsThumbnail())) {
+                    deletedFile(picture.getUrl());
+                    pictureRepository.deleteById(picture.getId());
+                }
+            });
             Picture thumbnail = Picture.of(uploadImageFile(thumbnailImage, home), home, true);
             pictureRepository.save(thumbnail);
         }
-
-
-
-
     }
 
     @Transactional
@@ -89,6 +103,9 @@ public class HomeService {
         List<Picture> pictures = new ArrayList<>();
 
         if (imageFiles != null) {
+
+
+
             imageFiles.forEach(file -> pictures.add(Picture.of(uploadImageFile(file, newHome), newHome, false)));
             pictureRepository.saveAll(pictures);
         }
@@ -133,6 +150,10 @@ public class HomeService {
             throw new CustomException(FileErrorCode.FILE_UPLOAD_FAILED);
         }
         return null;
+    }
+
+    private void deletedFile(String s3Url) {
+        awsS3Service.removeFile(s3Url);
     }
 
     private User validUser(Long userId) {


### PR DESCRIPTION
     - 수정할 때 다시 최대 5개 등록
     - imageFiles, thumbnail이 null이면 현행 유지
     - 값이 들어있으면 기존 이미지들 s3에서 제거 후 요청 받은 이미지로 재 업로드